### PR TITLE
Add HTTP status codes

### DIFF
--- a/middlewares/recoverable_middleware_test.go
+++ b/middlewares/recoverable_middleware_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Middlewares", func() {
 
 			tmp := bytes.NewBufferString("")
 			ctx.Response.BodyWriteTo(tmp)
-			Expect(ctx.Response.StatusCode()).To(Equal(fasthttp.StatusInternalServerError))
+			Expect(ctx.Response.StatusCode()).To(Equal(http.StatusInternalServerError))
 			Expect(strings.TrimSpace(tmp.String())).To(Equal(`{"code":"internal-server-error","message":"We encountered an internal error or misconfiguration and was unable to complete your request."}`))
 		})
 	})

--- a/result.go
+++ b/result.go
@@ -61,7 +61,7 @@ func (r *result) Error(err error) Result {
 		return r
 	}
 
-	errResponse := acquireErrorResponse(fasthttp.StatusInternalServerError)
+	errResponse := acquireErrorResponse(StatusInternalServerError)
 	if !errors.AggregateToResponse(err, errResponse) {
 		errResponse.SetParam("code", InternalServerErrorCode)
 		errResponse.SetParam("message", InternalServerErrorMessage)
@@ -75,7 +75,7 @@ func (r *result) Error(err error) Result {
 
 func (r *result) setStatus() {
 	if r.status == 0 {
-		r.status = fasthttp.StatusOK
+		r.status = StatusOK
 	}
 
 	r.r.SetStatusCode(r.status)

--- a/router.go
+++ b/router.go
@@ -35,7 +35,7 @@ func NewRouter(config RouterConfig) Router {
 	if config.NotFound == nil {
 		r.notFound = func(req Request, res Response) Result {
 			if req.WantsJSON() {
-				errResponse := acquireErrorResponse(fasthttp.StatusNotFound)
+				errResponse := acquireErrorResponse(StatusNotFound)
 				defer releaseErrorResponse(errResponse)
 
 				errResponse.SetParam("code", NotFoundErrorCode)
@@ -43,14 +43,14 @@ func NewRouter(config RouterConfig) Router {
 				return res.Status(errResponse.Status).Data(errResponse.Data)
 			}
 
-			return res.Status(fasthttp.StatusNotFound).Data(NotFoundErrorMessage)
+			return res.Status(StatusNotFound).Data(NotFoundErrorMessage)
 		}
 	}
 
 	if config.MethodNotAllowed == nil {
 		r.methodNotAllowed = func(req Request, res Response) Result {
 			if req.WantsJSON() {
-				errResponse := acquireErrorResponse(fasthttp.StatusMethodNotAllowed)
+				errResponse := acquireErrorResponse(StatusMethodNotAllowed)
 				defer releaseErrorResponse(errResponse)
 
 				errResponse.SetParam("code", MethodNotAllowedErrorCode)
@@ -58,7 +58,7 @@ func NewRouter(config RouterConfig) Router {
 				return res.Status(errResponse.Status).Data(errResponse.Data)
 			}
 
-			return res.Status(fasthttp.StatusMethodNotAllowed).Data(MethodNotAllowedErrorMessage)
+			return res.Status(StatusMethodNotAllowed).Data(MethodNotAllowedErrorMessage)
 		}
 	}
 

--- a/router_test.go
+++ b/router_test.go
@@ -806,7 +806,7 @@ var _ = g.Describe("Router", func() {
 			})
 			ctx := createRequestCtxFromPath("GET", "/value1")
 			router.Handler()(ctx)
-			Expect(ctx.Response.StatusCode()).To(Equal(fasthttp.StatusNotFound))
+			Expect(ctx.Response.StatusCode()).To(Equal(StatusNotFound))
 		})
 
 		g.It("should call the default method not allowed handler for wrong method", func() {
@@ -820,7 +820,7 @@ var _ = g.Describe("Router", func() {
 			router.Handler()(ctx)
 			methods := string(ctx.Response.Header.Peek("Allow"))
 			Expect(strings.Split(methods, ", ")).To(ConsistOf("GET", "OPTIONS"))
-			Expect(ctx.Response.StatusCode()).To(Equal(fasthttp.StatusMethodNotAllowed))
+			Expect(ctx.Response.StatusCode()).To(Equal(StatusMethodNotAllowed))
 		})
 
 		g.It("should call the default not found callback (JSON)", func() {
@@ -832,7 +832,7 @@ var _ = g.Describe("Router", func() {
 			ctx := createRequestCtxFromPath("GET", "/value1")
 			ctx.Request.Header.Set("Accept", "application/json, text/html, text/plain")
 			router.Handler()(ctx)
-			Expect(ctx.Response.StatusCode()).To(Equal(fasthttp.StatusNotFound))
+			Expect(ctx.Response.StatusCode()).To(Equal(StatusNotFound))
 			Expect(string(ctx.Response.Header.Peek("Content-Type"))).To(Equal("application/json; charset=utf-8"))
 		})
 
@@ -848,7 +848,7 @@ var _ = g.Describe("Router", func() {
 			router.Handler()(ctx)
 			methods := string(ctx.Response.Header.Peek("Allow"))
 			Expect(strings.Split(methods, ", ")).To(ConsistOf("GET", "OPTIONS"))
-			Expect(ctx.Response.StatusCode()).To(Equal(fasthttp.StatusMethodNotAllowed))
+			Expect(ctx.Response.StatusCode()).To(Equal(StatusMethodNotAllowed))
 			Expect(string(ctx.Response.Header.Peek("Content-Type"))).To(Equal("application/json; charset=utf-8"))
 		})
 

--- a/status.go
+++ b/status.go
@@ -1,0 +1,146 @@
+package http
+
+// HTTP status codes were stolen from valyala/fasthttp.
+const (
+	StatusContinue           = 100 // RFC 7231, 6.2.1
+	StatusSwitchingProtocols = 101 // RFC 7231, 6.2.2
+	StatusProcessing         = 102 // RFC 2518, 10.1
+
+	StatusOK                   = 200 // RFC 7231, 6.3.1
+	StatusCreated              = 201 // RFC 7231, 6.3.2
+	StatusAccepted             = 202 // RFC 7231, 6.3.3
+	StatusNonAuthoritativeInfo = 203 // RFC 7231, 6.3.4
+	StatusNoContent            = 204 // RFC 7231, 6.3.5
+	StatusResetContent         = 205 // RFC 7231, 6.3.6
+	StatusPartialContent       = 206 // RFC 7233, 4.1
+	StatusMultiStatus          = 207 // RFC 4918, 11.1
+	StatusAlreadyReported      = 208 // RFC 5842, 7.1
+	StatusIMUsed               = 226 // RFC 3229, 10.4.1
+
+	StatusMultipleChoices   = 300 // RFC 7231, 6.4.1
+	StatusMovedPermanently  = 301 // RFC 7231, 6.4.2
+	StatusFound             = 302 // RFC 7231, 6.4.3
+	StatusSeeOther          = 303 // RFC 7231, 6.4.4
+	StatusNotModified       = 304 // RFC 7232, 4.1
+	StatusUseProxy          = 305 // RFC 7231, 6.4.5
+	_                       = 306 // RFC 7231, 6.4.6 (Unused)
+	StatusTemporaryRedirect = 307 // RFC 7231, 6.4.7
+	StatusPermanentRedirect = 308 // RFC 7538, 3
+
+	StatusBadRequest                   = 400 // RFC 7231, 6.5.1
+	StatusUnauthorized                 = 401 // RFC 7235, 3.1
+	StatusPaymentRequired              = 402 // RFC 7231, 6.5.2
+	StatusForbidden                    = 403 // RFC 7231, 6.5.3
+	StatusNotFound                     = 404 // RFC 7231, 6.5.4
+	StatusMethodNotAllowed             = 405 // RFC 7231, 6.5.5
+	StatusNotAcceptable                = 406 // RFC 7231, 6.5.6
+	StatusProxyAuthRequired            = 407 // RFC 7235, 3.2
+	StatusRequestTimeout               = 408 // RFC 7231, 6.5.7
+	StatusConflict                     = 409 // RFC 7231, 6.5.8
+	StatusGone                         = 410 // RFC 7231, 6.5.9
+	StatusLengthRequired               = 411 // RFC 7231, 6.5.10
+	StatusPreconditionFailed           = 412 // RFC 7232, 4.2
+	StatusRequestEntityTooLarge        = 413 // RFC 7231, 6.5.11
+	StatusRequestURITooLong            = 414 // RFC 7231, 6.5.12
+	StatusUnsupportedMediaType         = 415 // RFC 7231, 6.5.13
+	StatusRequestedRangeNotSatisfiable = 416 // RFC 7233, 4.4
+	StatusExpectationFailed            = 417 // RFC 7231, 6.5.14
+	StatusTeapot                       = 418 // RFC 7168, 2.3.3
+	StatusUnprocessableEntity          = 422 // RFC 4918, 11.2
+	StatusLocked                       = 423 // RFC 4918, 11.3
+	StatusFailedDependency             = 424 // RFC 4918, 11.4
+	StatusUpgradeRequired              = 426 // RFC 7231, 6.5.15
+	StatusPreconditionRequired         = 428 // RFC 6585, 3
+	StatusTooManyRequests              = 429 // RFC 6585, 4
+	StatusRequestHeaderFieldsTooLarge  = 431 // RFC 6585, 5
+	StatusUnavailableForLegalReasons   = 451 // RFC 7725, 3
+
+	StatusInternalServerError           = 500 // RFC 7231, 6.6.1
+	StatusNotImplemented                = 501 // RFC 7231, 6.6.2
+	StatusBadGateway                    = 502 // RFC 7231, 6.6.3
+	StatusServiceUnavailable            = 503 // RFC 7231, 6.6.4
+	StatusGatewayTimeout                = 504 // RFC 7231, 6.6.5
+	StatusHTTPVersionNotSupported       = 505 // RFC 7231, 6.6.6
+	StatusVariantAlsoNegotiates         = 506 // RFC 2295, 8.1
+	StatusInsufficientStorage           = 507 // RFC 4918, 11.5
+	StatusLoopDetected                  = 508 // RFC 5842, 7.2
+	StatusNotExtended                   = 510 // RFC 2774, 7
+	StatusNetworkAuthenticationRequired = 511 // RFC 6585, 6
+)
+
+var (
+	statusMessages = map[int]string{
+		StatusContinue:           "Continue",
+		StatusSwitchingProtocols: "Switching Protocols",
+		StatusProcessing:         "Processing",
+
+		StatusOK:                   "OK",
+		StatusCreated:              "Created",
+		StatusAccepted:             "Accepted",
+		StatusNonAuthoritativeInfo: "Non-Authoritative Information",
+		StatusNoContent:            "No Content",
+		StatusResetContent:         "Reset Content",
+		StatusPartialContent:       "Partial Content",
+		StatusMultiStatus:          "Multi-Status",
+		StatusAlreadyReported:      "Already Reported",
+		StatusIMUsed:               "IM Used",
+
+		StatusMultipleChoices:   "Multiple Choices",
+		StatusMovedPermanently:  "Moved Permanently",
+		StatusFound:             "Found",
+		StatusSeeOther:          "See Other",
+		StatusNotModified:       "Not Modified",
+		StatusUseProxy:          "Use Proxy",
+		StatusTemporaryRedirect: "Temporary Redirect",
+		StatusPermanentRedirect: "Permanent Redirect",
+
+		StatusBadRequest:                   "Bad Request",
+		StatusUnauthorized:                 "Unauthorized",
+		StatusPaymentRequired:              "Payment Required",
+		StatusForbidden:                    "Forbidden",
+		StatusNotFound:                     "Not Found",
+		StatusMethodNotAllowed:             "Method Not Allowed",
+		StatusNotAcceptable:                "Not Acceptable",
+		StatusProxyAuthRequired:            "Proxy Authentication Required",
+		StatusRequestTimeout:               "Request Timeout",
+		StatusConflict:                     "Conflict",
+		StatusGone:                         "Gone",
+		StatusLengthRequired:               "Length Required",
+		StatusPreconditionFailed:           "Precondition Failed",
+		StatusRequestEntityTooLarge:        "Request Entity Too Large",
+		StatusRequestURITooLong:            "Request URI Too Long",
+		StatusUnsupportedMediaType:         "Unsupported Media Type",
+		StatusRequestedRangeNotSatisfiable: "Requested Range Not Satisfiable",
+		StatusExpectationFailed:            "Expectation Failed",
+		StatusTeapot:                       "I'm a teapot",
+		StatusUnprocessableEntity:          "Unprocessable Entity",
+		StatusLocked:                       "Locked",
+		StatusFailedDependency:             "Failed Dependency",
+		StatusUpgradeRequired:              "Upgrade Required",
+		StatusPreconditionRequired:         "Precondition Required",
+		StatusTooManyRequests:              "Too Many Requests",
+		StatusRequestHeaderFieldsTooLarge:  "Request Header Fields Too Large",
+		StatusUnavailableForLegalReasons:   "Unavailable For Legal Reasons",
+
+		StatusInternalServerError:           "Internal Server Error",
+		StatusNotImplemented:                "Not Implemented",
+		StatusBadGateway:                    "Bad Gateway",
+		StatusServiceUnavailable:            "Service Unavailable",
+		StatusGatewayTimeout:                "Gateway Timeout",
+		StatusHTTPVersionNotSupported:       "HTTP Version Not Supported",
+		StatusVariantAlsoNegotiates:         "Variant Also Negotiates",
+		StatusInsufficientStorage:           "Insufficient Storage",
+		StatusLoopDetected:                  "Loop Detected",
+		StatusNotExtended:                   "Not Extended",
+		StatusNetworkAuthenticationRequired: "Network Authentication Required",
+	}
+)
+
+// StatusMessage returns HTTP status message for the given status code.
+func StatusMessage(statusCode int) string {
+	s := statusMessages[statusCode]
+	if s == "" {
+		s = "Unknown Status Code"
+	}
+	return s
+}


### PR DESCRIPTION
This PR solves a common problem which is depending on `fasthttp` or `net/http` to set status codes. 