### PR TITLE
Add lab259/cors and tests for middlewares

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,7 @@ $(EXAMPLES): %:
 	@:
 
 run:
-	@if [ ! -z "$(EXAMPLE)" ]; then \
-		go run ./examples/$(EXAMPLE); \
-	else \
-		echo "Usage: make [$(EXAMPLES)] run"; \
-		echo "The environment variable \`EXAMPLE\` is not defined."; \
-	fi
+	@test ! -z "$(EXAMPLE)" && go run ./examples/$(EXAMPLE) || echo "Usage: make [$(EXAMPLES)] run"
 
 build:
 	@test -d ./examples && $(foreach example,$(EXAMPLES),go build "-ldflags=$(LDFLAGS)" -o ./bin/$(example) -v ./examples/$(example) &&) :
@@ -42,9 +37,9 @@ plot-mem:
 
 coverage-ci:
 	@mkdir -p $(COVERDIR)
-	@ginkgo -r -covermode=count --cover --trace ./
+	@ginkgo -r -covermode=count --cover --trace ./...
 	@echo "mode: count" > "${COVERAGEFILE}"
-	@find . -type f -name *.coverprofile -exec grep -h -v "^mode:" {} >> "${COVERAGEFILE}" \; -exec rm -f {} \;
+	@find . -type f -name '*.coverprofile' -exec cat {} \; -exec rm -f {} \; | grep -h -v "^mode:" >> ${COVERAGEFILE}
 
 coverage: coverage-ci
 	@sed -i -e "s|_$(CURDIR)/|./|g" "${COVERAGEFILE}"

--- a/application.go
+++ b/application.go
@@ -44,14 +44,6 @@ func (app *Application) Name() string {
 	return app.Configuration.Name
 }
 
-func (app *Application) LoadConfiguration() (interface{}, error) {
-	return nil, nil
-}
-
-func (app *Application) ApplyConfiguration(interface{}) error {
-	return nil
-}
-
 func (app *Application) Restart() error {
 	if err := app.Stop(); err != nil {
 		return err

--- a/fasthttp_service.go
+++ b/fasthttp_service.go
@@ -68,11 +68,7 @@ func (service *FasthttpService) Start() error {
 		return service.Server.ListenAndServe(service.Configuration.Bind)
 	}
 
-	return service.Server.ListenAndServeTLS(
-		service.Configuration.Bind,
-		service.Configuration.TLS.CertFile,
-		service.Configuration.TLS.KeyFile,
-	)
+	return service.Server.ListenAndServeTLS(service.Configuration.Bind, service.Configuration.TLS.CertFile, service.Configuration.TLS.KeyFile)
 }
 
 // Stop closes the listener and waits the `Start` to stop.

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,10 @@ module github.com/lab259/hermes
 go 1.12
 
 require (
-	github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a
 	github.com/jamillosantos/macchiato v0.0.0-20171220130318-3be045cc5033
 	github.com/klauspost/compress v1.5.0 // indirect
 	github.com/klauspost/cpuid v1.2.1 // indirect
-	github.com/lab259/errors v2.1.0+incompatible
+	github.com/lab259/cors v0.1.0
 	github.com/lab259/errors/v2 v2.2.0
 	github.com/lab259/go-rscsrv v0.2.1
 	github.com/lab259/rlog v2.0.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/jamillosantos/macchiato v0.0.0-20171220130318-3be045cc5033
 	github.com/klauspost/compress v1.5.0 // indirect
 	github.com/klauspost/cpuid v1.2.1 // indirect
+	github.com/lab259/errors v2.1.0+incompatible
 	github.com/lab259/errors/v2 v2.2.0
 	github.com/lab259/go-rscsrv v0.2.1
 	github.com/lab259/rlog v2.0.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a h1:XVdatQFSP2YhJGjqLLIfW8QBk4loz/SCe/PxkXDiW+s=
-github.com/AdhityaRamadhanus/fasthttpcors v0.0.0-20170121111917-d4c07198763a/go.mod h1:C0A1KeiVHs+trY6gUTPhhGammbrZ30ZfXRW/nuT7HLw=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -31,8 +29,8 @@ github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM52
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.1 h1:vJi+O/nMdFt0vqm8NZBI6wzALWdA2X+egi0ogNyrC/w=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
-github.com/lab259/errors v2.1.0+incompatible h1:spmhLIqKUzsog6XhwOpeDY0oX8Q5NguDkMAtCB6trws=
-github.com/lab259/errors v2.1.0+incompatible/go.mod h1:MDDGb8dSRNqu9IVhE4C+nF2qFqPPO+n6/Nn1AqyI6rI=
+github.com/lab259/cors v0.1.0 h1:0806vcp/WBZBqwPRBA6sowKxE6/Mf6IekdWR+qC5tSQ=
+github.com/lab259/cors v0.1.0/go.mod h1:irvlJlQvQX/3L0ouMuvV4XNMSKP7a1+45aexLgqnojQ=
 github.com/lab259/errors/v2 v2.2.0 h1:I2YKNMygf9LiBsyt0RkRRRFaVFUqSGHBzsG7Pe21zKk=
 github.com/lab259/errors/v2 v2.2.0/go.mod h1:bcuh1ha3APn7gzh8k1QMzuFXpqfBplbVKyClNpZ+H6U=
 github.com/lab259/go-rscsrv v0.2.1 h1:/crfSH3rZXUTfqNBw+B1qMbkiuRN5Swucb10nmIV1Os=

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM52
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.2.1 h1:vJi+O/nMdFt0vqm8NZBI6wzALWdA2X+egi0ogNyrC/w=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/lab259/errors v2.1.0+incompatible h1:spmhLIqKUzsog6XhwOpeDY0oX8Q5NguDkMAtCB6trws=
+github.com/lab259/errors v2.1.0+incompatible/go.mod h1:MDDGb8dSRNqu9IVhE4C+nF2qFqPPO+n6/Nn1AqyI6rI=
 github.com/lab259/errors/v2 v2.2.0 h1:I2YKNMygf9LiBsyt0RkRRRFaVFUqSGHBzsG7Pe21zKk=
 github.com/lab259/errors/v2 v2.2.0/go.mod h1:bcuh1ha3APn7gzh8k1QMzuFXpqfBplbVKyClNpZ+H6U=
 github.com/lab259/go-rscsrv v0.2.1 h1:/crfSH3rZXUTfqNBw+B1qMbkiuRN5Swucb10nmIV1Os=

--- a/middlewares/cors_middleware.go
+++ b/middlewares/cors_middleware.go
@@ -1,23 +1,23 @@
 package middlewares
 
 import (
-	cors "github.com/AdhityaRamadhanus/fasthttpcors"
+	"github.com/lab259/cors"
 	"github.com/lab259/hermes"
 	"github.com/valyala/fasthttp"
 )
 
 func DefaultCorsMiddleware() hermes.Middleware {
-	return wrapCorsMiddleware(cors.DefaultHandler())
+	return wrapCorsMiddleware(cors.Default())
 }
 
 func NewCorsMiddleware(options cors.Options) hermes.Middleware {
-	return wrapCorsMiddleware(cors.NewCorsHandler(options))
+	return wrapCorsMiddleware(cors.New(options))
 }
 
-func wrapCorsMiddleware(withCors *cors.CorsHandler) hermes.Middleware {
+func wrapCorsMiddleware(withCors *cors.Cors) hermes.Middleware {
 	return func(req hermes.Request, res hermes.Response, next hermes.Handler) hermes.Result {
 		canContinue := false
-		withCors.CorsMiddleware(func(ctx *fasthttp.RequestCtx) {
+		withCors.Handler(func(ctx *fasthttp.RequestCtx) {
 			canContinue = true
 		})(req.Raw())
 		if canContinue {

--- a/middlewares/cors_middleware_test.go
+++ b/middlewares/cors_middleware_test.go
@@ -1,0 +1,432 @@
+package middlewares_test
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/lab259/cors"
+	"github.com/lab259/hermes"
+	"github.com/lab259/hermes/middlewares"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/valyala/fasthttp"
+)
+
+var _ = Describe("Middlewares", func() {
+	Describe("CORS Middleware", func() {
+		var allHeaders = []string{
+			"Vary",
+			"Access-Control-Allow-Origin",
+			"Access-Control-Allow-Methods",
+			"Access-Control-Allow-Headers",
+			"Access-Control-Allow-Credentials",
+			"Access-Control-Max-Age",
+			"Access-Control-Expose-Headers",
+		}
+
+		cases := []struct {
+			name       string
+			options    cors.Options
+			method     string
+			reqHeaders map[string]string
+			resHeaders map[string]string
+		}{
+			{
+				"Default",
+				cors.Options{
+					// Intentionally left blank.
+				},
+				"GET",
+				map[string]string{},
+				map[string]string{
+					"Vary": "Origin",
+				},
+			},
+			{
+				"NoConfig",
+				cors.Options{
+					// Intentionally left blank.
+				},
+				"GET",
+				map[string]string{},
+				map[string]string{
+					"Vary": "Origin",
+				},
+			},
+			{
+				"MatchAllOrigin",
+				cors.Options{
+					AllowedOrigins: []string{"*"},
+				},
+				"GET",
+				map[string]string{
+					"Origin": "http://foobar.com",
+				},
+				map[string]string{
+					"Vary":                        "Origin",
+					"Access-Control-Allow-Origin": "*",
+				},
+			},
+			{
+				"MatchAllOriginWithCredentials",
+				cors.Options{
+					AllowedOrigins:   []string{"*"},
+					AllowCredentials: true,
+				},
+				"GET",
+				map[string]string{
+					"Origin": "http://foobar.com",
+				},
+				map[string]string{
+					"Vary":                             "Origin",
+					"Access-Control-Allow-Origin":      "*",
+					"Access-Control-Allow-Credentials": "true",
+				},
+			},
+			{
+				"AllowedOrigin",
+				cors.Options{
+					AllowedOrigins: []string{"http://foobar.com"},
+				},
+				"GET",
+				map[string]string{
+					"Origin": "http://foobar.com",
+				},
+				map[string]string{
+					"Vary":                        "Origin",
+					"Access-Control-Allow-Origin": "http://foobar.com",
+				},
+			},
+			{
+				"WildcardOrigin",
+				cors.Options{
+					AllowedOrigins: []string{"http://*.bar.com"},
+				},
+				"GET",
+				map[string]string{
+					"Origin": "http://foo.bar.com",
+				},
+				map[string]string{
+					"Vary":                        "Origin",
+					"Access-Control-Allow-Origin": "http://foo.bar.com",
+				},
+			},
+			{
+				"DisallowedOrigin",
+				cors.Options{
+					AllowedOrigins: []string{"http://foobar.com"},
+				},
+				"GET",
+				map[string]string{
+					"Origin": "http://barbaz.com",
+				},
+				map[string]string{
+					"Vary": "Origin",
+				},
+			},
+			{
+				"DisallowedWildcardOrigin",
+				cors.Options{
+					AllowedOrigins: []string{"http://*.bar.com"},
+				},
+				"GET",
+				map[string]string{
+					"Origin": "http://foo.baz.com",
+				},
+				map[string]string{
+					"Vary": "Origin",
+				},
+			},
+			{
+				"AllowedOriginFuncMatch",
+				cors.Options{
+					AllowOriginFunc: func(o string) bool {
+						return regexp.MustCompile("^http://foo").MatchString(o)
+					},
+				},
+				"GET",
+				map[string]string{
+					"Origin": "http://foobar.com",
+				},
+				map[string]string{
+					"Vary":                        "Origin",
+					"Access-Control-Allow-Origin": "http://foobar.com",
+				},
+			},
+			{
+				"AllowOriginRequestFuncMatch",
+				cors.Options{
+					AllowOriginRequestFunc: func(ctx *fasthttp.RequestCtx, o string) bool {
+						return regexp.MustCompile("^http://foo").MatchString(o) && string(ctx.Request.Header.Peek("Authorization")) == "secret"
+					},
+				},
+				"GET",
+				map[string]string{
+					"Origin":        "http://foobar.com",
+					"Authorization": "secret",
+				},
+				map[string]string{
+					"Vary":                        "Origin",
+					"Access-Control-Allow-Origin": "http://foobar.com",
+				},
+			},
+			{
+				"AllowOriginRequestFuncNotMatch",
+				cors.Options{
+					AllowOriginRequestFunc: func(ctx *fasthttp.RequestCtx, o string) bool {
+						return regexp.MustCompile("^http://foo").MatchString(o) && string(ctx.Request.Header.Peek("Authorization")) == "secret"
+					},
+				},
+				"GET",
+				map[string]string{
+					"Origin":        "http://foobar.com",
+					"Authorization": "not-secret",
+				},
+				map[string]string{
+					"Vary": "Origin",
+				},
+			},
+			{
+				"MaxAge",
+				cors.Options{
+					AllowedOrigins: []string{"http://example.com/"},
+					AllowedMethods: []string{"GET"},
+					MaxAge:         10,
+				},
+				"OPTIONS",
+				map[string]string{
+					"Origin":                        "http://example.com/",
+					"Access-Control-Request-Method": "GET",
+				},
+				map[string]string{
+					"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+					"Access-Control-Allow-Origin":  "http://example.com/",
+					"Access-Control-Allow-Methods": "GET",
+					"Access-Control-Max-Age":       "10",
+				},
+			},
+			{
+				"AllowedMethod",
+				cors.Options{
+					AllowedOrigins: []string{"http://foobar.com"},
+					AllowedMethods: []string{"PUT", "DELETE"},
+				},
+				"OPTIONS",
+				map[string]string{
+					"Origin":                        "http://foobar.com",
+					"Access-Control-Request-Method": "PUT",
+				},
+				map[string]string{
+					"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+					"Access-Control-Allow-Origin":  "http://foobar.com",
+					"Access-Control-Allow-Methods": "PUT",
+				},
+			},
+			{
+				"DisallowedMethod",
+				cors.Options{
+					AllowedOrigins: []string{"http://foobar.com"},
+					AllowedMethods: []string{"PUT", "DELETE"},
+				},
+				"OPTIONS",
+				map[string]string{
+					"Origin":                        "http://foobar.com",
+					"Access-Control-Request-Method": "PATCH",
+				},
+				map[string]string{
+					"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				},
+			},
+			{
+				"AllowedHeaders",
+				cors.Options{
+					AllowedOrigins: []string{"http://foobar.com"},
+					AllowedHeaders: []string{"X-Header-1", "x-header-2"},
+				},
+				"OPTIONS",
+				map[string]string{
+					"Origin":                         "http://foobar.com",
+					"Access-Control-Request-Method":  "GET",
+					"Access-Control-Request-Headers": "X-Header-2, X-HEADER-1",
+				},
+				map[string]string{
+					"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+					"Access-Control-Allow-Origin":  "http://foobar.com",
+					"Access-Control-Allow-Methods": "GET",
+					"Access-Control-Allow-Headers": "X-Header-2, X-Header-1",
+				},
+			},
+			{
+				"DefaultAllowedHeaders",
+				cors.Options{
+					AllowedOrigins: []string{"http://foobar.com"},
+					AllowedHeaders: []string{},
+				},
+				"OPTIONS",
+				map[string]string{
+					"Origin":                         "http://foobar.com",
+					"Access-Control-Request-Method":  "GET",
+					"Access-Control-Request-Headers": "X-Requested-With",
+				},
+				map[string]string{
+					"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+					"Access-Control-Allow-Origin":  "http://foobar.com",
+					"Access-Control-Allow-Methods": "GET",
+					"Access-Control-Allow-Headers": "X-Requested-With",
+				},
+			},
+			{
+				"AllowedWildcardHeader",
+				cors.Options{
+					AllowedOrigins: []string{"http://foobar.com"},
+					AllowedHeaders: []string{"*"},
+				},
+				"OPTIONS",
+				map[string]string{
+					"Origin":                         "http://foobar.com",
+					"Access-Control-Request-Method":  "GET",
+					"Access-Control-Request-Headers": "X-Header-2, X-HEADER-1",
+				},
+				map[string]string{
+					"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+					"Access-Control-Allow-Origin":  "http://foobar.com",
+					"Access-Control-Allow-Methods": "GET",
+					"Access-Control-Allow-Headers": "X-Header-2, X-Header-1",
+				},
+			},
+			{
+				"DisallowedHeader",
+				cors.Options{
+					AllowedOrigins: []string{"http://foobar.com"},
+					AllowedHeaders: []string{"X-Header-1", "x-header-2"},
+				},
+				"OPTIONS",
+				map[string]string{
+					"Origin":                         "http://foobar.com",
+					"Access-Control-Request-Method":  "GET",
+					"Access-Control-Request-Headers": "X-Header-3, X-Header-1",
+				},
+				map[string]string{
+					"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				},
+			},
+			{
+				"OriginHeader",
+				cors.Options{
+					AllowedOrigins: []string{"http://foobar.com"},
+				},
+				"OPTIONS",
+				map[string]string{
+					"Origin":                         "http://foobar.com",
+					"Access-Control-Request-Method":  "GET",
+					"Access-Control-Request-Headers": "origin",
+				},
+				map[string]string{
+					"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+					"Access-Control-Allow-Origin":  "http://foobar.com",
+					"Access-Control-Allow-Methods": "GET",
+					"Access-Control-Allow-Headers": "Origin",
+				},
+			},
+			{
+				"ExposedHeader",
+				cors.Options{
+					AllowedOrigins: []string{"http://foobar.com"},
+					ExposedHeaders: []string{"X-Header-1", "x-header-2"},
+				},
+				"GET",
+				map[string]string{
+					"Origin": "http://foobar.com",
+				},
+				map[string]string{
+					"Vary":                          "Origin",
+					"Access-Control-Allow-Origin":   "http://foobar.com",
+					"Access-Control-Expose-Headers": "X-Header-1, X-Header-2",
+				},
+			},
+			{
+				"AllowedCredentials",
+				cors.Options{
+					AllowedOrigins:   []string{"http://foobar.com"},
+					AllowCredentials: true,
+				},
+				"OPTIONS",
+				map[string]string{
+					"Origin":                        "http://foobar.com",
+					"Access-Control-Request-Method": "GET",
+				},
+				map[string]string{
+					"Vary":                             "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+					"Access-Control-Allow-Origin":      "http://foobar.com",
+					"Access-Control-Allow-Methods":     "GET",
+					"Access-Control-Allow-Credentials": "true",
+				},
+			},
+			{
+				"OptionPassthrough",
+				cors.Options{
+					OptionsPassthrough: true,
+				},
+				"OPTIONS",
+				map[string]string{
+					"Origin":                        "http://foobar.com",
+					"Access-Control-Request-Method": "GET",
+				},
+				map[string]string{
+					"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+					"Access-Control-Allow-Origin":  "*",
+					"Access-Control-Allow-Methods": "GET",
+				},
+			},
+			{
+				"NonPreflightOptions",
+				cors.Options{
+					AllowedOrigins: []string{"http://foobar.com"},
+				},
+				"OPTIONS",
+				map[string]string{},
+				map[string]string{},
+			},
+		}
+		for i := range cases {
+			tc := cases[i]
+			It(tc.name, func() {
+				r := hermes.DefaultRouter()
+
+				if tc.name == "Default" {
+					r.Use(middlewares.DefaultCorsMiddleware())
+				} else {
+					r.Use(middlewares.NewCorsMiddleware(tc.options))
+				}
+
+				r.Get("/something", func(req hermes.Request, res hermes.Response) hermes.Result {
+					return res.End()
+				})
+
+				ctx := fasthttp.RequestCtx{}
+				ctx.Request.Header.SetMethod(tc.method)
+				ctx.Request.SetRequestURI("http://example.com/foo")
+				for name, value := range tc.reqHeaders {
+					ctx.Request.Header.Add(name, value)
+				}
+
+				r.Handler()(&ctx)
+
+				headers := make(map[string][]string, ctx.Response.Header.Len())
+				ctx.Response.Header.VisitAll(func(key []byte, value []byte) {
+					if arr, found := headers[string(key)]; found {
+						headers[string(key)] = append(arr, string(value))
+					} else {
+						headers[string(key)] = []string{string(value)}
+					}
+				})
+
+				for _, name := range allHeaders {
+					got := strings.Join(headers[name], ", ")
+					want := tc.resHeaders[name]
+					Expect(got).To(Equal(want))
+				}
+			})
+		}
+	})
+})

--- a/middlewares/logging_middleware_test.go
+++ b/middlewares/logging_middleware_test.go
@@ -1,0 +1,56 @@
+package middlewares_test
+
+import (
+	"bytes"
+
+	"github.com/lab259/rlog"
+
+	"github.com/lab259/hermes"
+	"github.com/lab259/hermes/middlewares"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/valyala/fasthttp"
+)
+
+var _ = Describe("Middlewares", func() {
+	Describe("Logging Middleware", func() {
+		It("should log requests", func() {
+			var buf bytes.Buffer
+			rlog.SetOutput(&buf)
+
+			r := hermes.DefaultRouter()
+			r.Use(middlewares.LoggingMiddleware)
+			r.Get("/something", func(req hermes.Request, res hermes.Response) hermes.Result {
+				return res.End()
+			})
+			r.Post("/something", func(req hermes.Request, res hermes.Response) hermes.Result {
+				return res.End()
+			})
+			r.Put("/something/else", func(req hermes.Request, res hermes.Response) hermes.Result {
+				return res.End()
+			})
+
+			handler := r.Handler()
+
+			ctx1 := &fasthttp.RequestCtx{}
+			ctx1.Request.Header.SetMethod("GET")
+			ctx1.Request.URI().SetPath("/something")
+			handler(ctx1)
+
+			ctx2 := &fasthttp.RequestCtx{}
+			ctx2.Request.Header.SetMethod("POST")
+			ctx2.Request.URI().SetPath("/something")
+			handler(ctx2)
+
+			ctx3 := &fasthttp.RequestCtx{}
+			ctx3.Request.Header.SetMethod("PUT")
+			ctx3.Request.URI().SetPath("/something/else")
+			handler(ctx3)
+
+			logs := buf.String()
+			Expect(logs).To(ContainSubstring("GET: /something                                         request_id=0"))
+			Expect(logs).To(ContainSubstring("POST: /something                                         request_id=0"))
+			Expect(logs).To(ContainSubstring("PUT: /something/else                                    request_id=0"))
+		})
+	})
+})

--- a/middlewares/recoverable_middleware_test.go
+++ b/middlewares/recoverable_middleware_test.go
@@ -2,8 +2,10 @@ package middlewares_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 
+	"github.com/lab259/errors/v2"
 	"github.com/lab259/hermes"
 	"github.com/lab259/hermes/middlewares"
 	. "github.com/onsi/ginkgo"
@@ -30,6 +32,30 @@ var _ = Describe("Middlewares", func() {
 			ctx.Response.BodyWriteTo(tmp)
 			Expect(ctx.Response.StatusCode()).To(Equal(hermes.StatusInternalServerError))
 			Expect(strings.TrimSpace(tmp.String())).To(Equal(`{"code":"internal-server-error","message":"We encountered an internal error or misconfiguration and was unable to complete your request."}`))
+		})
+
+		It("should recover from panic (formatted error)", func() {
+			r := hermes.DefaultRouter()
+			r.Use(middlewares.RecoverableMiddleware)
+			r.Get("/should-panic", func(req hermes.Request, res hermes.Response) hermes.Result {
+				panic(errors.Wrap(errors.New("forced-error"), "Something really bad happened.", hermes.StatusBadRequest, errors.Code("forced-error"), errors.Module("testing")))
+			})
+
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.Header.SetMethod("GET")
+			ctx.Request.URI().SetPath("/should-panic")
+
+			r.Handler()(ctx)
+
+			tmp := bytes.NewBufferString("")
+			ctx.Response.BodyWriteTo(tmp)
+			Expect(ctx.Response.StatusCode()).To(Equal(hermes.StatusBadRequest))
+
+			var errData map[string]interface{}
+			Expect(json.Unmarshal(tmp.Bytes(), &errData))
+			Expect(errData["code"]).To(Equal("forced-error"))
+			Expect(errData["message"]).To(Equal("Something really bad happened."))
+			Expect(errData["module"]).To(Equal("testing"))
 		})
 	})
 })


### PR DESCRIPTION
We replace `fasthttpcors` with [`lab259/cors`](//github.com/lab259/cors) and improve our code coverage.