### PR TITLE
Replace embedded Mutex with an unexported attribute

### DIFF
--- a/service_state.go
+++ b/service_state.go
@@ -3,18 +3,18 @@ package hermes
 import "sync"
 
 type serviceState struct {
-	sync.RWMutex
+	mutex sync.RWMutex
 	_running bool
 }
 
 func (service *serviceState) isRunning() bool {
-	service.RLock()
+	service.mutex.RLock()
 	defer service.RUnlock()
 	return service._running
 }
 
 func (service *serviceState) setRunning(v bool) {
-	service.Lock()
+	service.mutex.Lock()
 	service._running = v
-	service.Unlock()
+	service.mutex.Unlock()
 }


### PR DESCRIPTION
In the ServiceState struct, we have an embedded RWMutex which is a problem, because other packages can Lock and Unlock the Mutex (which should be for internal usage only).

Resolves: https://github.com/lab259/hermes/issues/20